### PR TITLE
Fix impossible reference arguments

### DIFF
--- a/library/video_transforms/aligned_edge_detection_process.h
+++ b/library/video_transforms/aligned_edge_detection_process.h
@@ -92,10 +92,10 @@ private:
 
   // Internal helper function
   void process_region( const input_image_t& input_image,
-                       input_image_t& aligned_edges,
-                       input_image_t& combined_edges,
-                       float_image_t& grad_i_buffer,
-                       float_image_t& grad_j_buffer );
+                       input_image_t aligned_edges,
+                       input_image_t combined_edges,
+                       float_image_t grad_i_buffer,
+                       float_image_t grad_j_buffer );
 };
 
 

--- a/library/video_transforms/aligned_edge_detection_process.txx
+++ b/library/video_transforms/aligned_edge_detection_process.txx
@@ -176,10 +176,10 @@ template <typename PixType>
 void
 aligned_edge_detection_process<PixType>
 ::process_region( const input_image_t& input_image,
-                  input_image_t& aligned_edges,
-                  input_image_t& combined_edges,
-                  float_image_t& grad_i_buffer,
-                  float_image_t& grad_j_buffer )
+                  input_image_t aligned_edges,
+                  input_image_t combined_edges,
+                  float_image_t grad_i_buffer,
+                  float_image_t grad_j_buffer )
 {
   calculate_aligned_edges( input_image,
                            threshold_,
@@ -214,6 +214,7 @@ aligned_edge_detection_process<PixType>
     }
     else
     {
+      // FIXME this can't be right; need to copy the data into the view
       combined_edges = joint_nms_edges;
     }
   }

--- a/library/video_transforms/high_pass_filter_process.h
+++ b/library/video_transforms/high_pass_filter_process.h
@@ -104,7 +104,7 @@ private:
 
   thread_sys_sptr_t threads_;
 
-  void process_region( const image_t& input, image_t& output );
+  void process_region( const image_t& input, image_t output );
 };
 
 

--- a/library/video_transforms/high_pass_filter_process.txx
+++ b/library/video_transforms/high_pass_filter_process.txx
@@ -219,7 +219,7 @@ high_pass_filter_process<PixType>
 template <typename PixType>
 void
 high_pass_filter_process<PixType>
-::process_region( const image_t& input_region, image_t& output_region )
+::process_region( const image_t& input_region, image_t output_region )
 {
   if( mode_ == BOX )
   {

--- a/library/video_transforms/inpainting_process.h
+++ b/library/video_transforms/inpainting_process.h
@@ -105,7 +105,7 @@ private:
 
   void inpaint( const image_t& input,
                 const mask_t& mask,
-                image_t& output ) const;
+                image_t output ) const;
 
   void compute_warped_image();
 

--- a/library/video_transforms/inpainting_process.txx
+++ b/library/video_transforms/inpainting_process.txx
@@ -727,7 +727,7 @@ inpainting_process<PixType>
 template <typename PixType>
 void
 inpainting_process<PixType>
-::inpaint( const image_t& input, const mask_t& mask, image_t& output ) const
+::inpaint( const image_t& input, const mask_t& mask, image_t output ) const
 {
   // Validate input image
   if( !input || input.size() == 0 || algorithm_ == NONE )


### PR DESCRIPTION
The way `threaded_image_transform` is implemented, there is no way it can pass an argument to the transform function by reference in any meaningful way. Fortunately, since the arguments are `vil_image_view`s, it also doesn't need to; a copy of the view will still have a reference to the underlying storage. Accordingly, remove impossible reference qualifications from `vil_image_view` parameters meant to convey output buffers.

This appears as a build error with newer versions of Boost, which are stricter about this sort of nonsense. (See also https://stackoverflow.com/questions/45549724.)

Note: There is (at least) one spot in which an output parameter is being assigned. This code is probably broken (on master also; this change, which should not have an actual behavioral effect, just makes it more obvious that it's broken.)