### PR TITLE
Option to explicitly disable gdal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,29 +288,36 @@ if( VIDTK_ENABLE_SHAPELIB )
   add_definitions("-DSHAPELIB_ENABLED")
 endif()
 
+
+option(BURNOUT_DISABLE_GDAL FALSE)
 set(VIDTK_HAS_GDAL FALSE)
-find_package(GDAL)
-if( GDAL_FOUND )
-  # We need to build the file in a line-by-line fashon because of
-  # portability with end of line markers.
-  file( WRITE  ${CMAKE_BINARY_DIR}/test_gdal_version.cxx "#include <gdal_version.h>\n" )
-  file( APPEND ${CMAKE_BINARY_DIR}/test_gdal_version.cxx "#if ( GDAL_COMPUTE_VERSION( 1, 11, 0  ) != GDAL_VERSION_NUM )\n")
-  file( APPEND ${CMAKE_BINARY_DIR}/test_gdal_version.cxx "#error \"GDAL Not required version: $GDAL_VERSION_NUM\"\n" )
-  file( APPEND ${CMAKE_BINARY_DIR}/test_gdal_version.cxx "#endif\n")
-  file( APPEND ${CMAKE_BINARY_DIR}/test_gdal_version.cxx "int main() { } // just need some code\n")
+if (not BURNOUT_DISABLE_GDAL)
+  find_package(GDAL)
+  if( GDAL_FOUND )
+    # We need to build the file in a line-by-line fashon because of
+    # portability with end of line markers.
+    file( WRITE  ${CMAKE_BINARY_DIR}/test_gdal_version.cxx "#include <gdal_version.h>\n" )
+    file( APPEND ${CMAKE_BINARY_DIR}/test_gdal_version.cxx "#if ( GDAL_COMPUTE_VERSION( 1, 11, 0  ) != GDAL_VERSION_NUM )\n")
+    file( APPEND ${CMAKE_BINARY_DIR}/test_gdal_version.cxx "#error \"GDAL Not required version: $GDAL_VERSION_NUM\"\n" )
+    file( APPEND ${CMAKE_BINARY_DIR}/test_gdal_version.cxx "#endif\n")
+    file( APPEND ${CMAKE_BINARY_DIR}/test_gdal_version.cxx "int main() { } // just need some code\n")
 
-  TRY_COMPILE( GDAL_VERSION_MATCH
-             ${CMAKE_BINARY_DIR}
-             ${CMAKE_BINARY_DIR}/test_gdal_version.cxx
-             COMPILE_DEFINITIONS "-I${GDAL_INCLUDE_DIR}"
-             OUTPUT_VARIABLE OUTPUT)
+    TRY_COMPILE( GDAL_VERSION_MATCH
+               ${CMAKE_BINARY_DIR}
+               ${CMAKE_BINARY_DIR}/test_gdal_version.cxx
+               COMPILE_DEFINITIONS "-I${GDAL_INCLUDE_DIR}"
+               OUTPUT_VARIABLE OUTPUT)
 
-  if( GDAL_VERSION_MATCH )
-    set(VIDTK_HAS_GDAL TRUE)
-    include_directories(SYSTEM ${GDAL_INCLUDE_DIR})
-  else()
-    message( WARNING "GDAL found, but not needed version. Need version: 1.11" )
-    message(${OUTPUT})
+    if( GDAL_VERSION_MATCH )
+      set(VIDTK_HAS_GDAL TRUE)
+      include_directories(SYSTEM ${GDAL_INCLUDE_DIR})
+    else()
+      message( WARNING "GDAL found, but not needed version. Need version: 1.11" )
+      message(${OUTPUT})
+      unset(GDAL_CONFIG)
+      unset(GDAL_INCLUDE_DIR)
+      unset(GDAL_LIBRARY)
+    endif()
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,7 +291,7 @@ endif()
 
 option(BURNOUT_DISABLE_GDAL FALSE)
 set(VIDTK_HAS_GDAL FALSE)
-if (not BURNOUT_DISABLE_GDAL)
+if (NOT BURNOUT_DISABLE_GDAL)
   find_package(GDAL)
   if( GDAL_FOUND )
     # We need to build the file in a line-by-line fashon because of


### PR DESCRIPTION
This fixes a build error on VIAME where fletch GDAL is not enabled, but a system GDAL is installed. 
Once this is merged the VIAME fix can be found here: Kitware/VIAME#31

The old behavior would find GDAL, and error like this: 

```
[  4%] Performing install step for 'fletch'
Running fletch install
Done
[  6%] Completed 'fletch'
[ 14%] Built target fletch
[ 15%] Performing configure step for 'burnout'
-- TinyXML version: 2.6.2
CMake Warning at CMakeLists.txt:312 (message):
  GDAL found, but not needed version.  Need version: 1.11


Change Dir: /home/joncrall/code/VIAME/build-py2/build/src/burnout-build/CMakeFiles/CMakeTmp

Run Build Command:"/usr/bin/make" "cmTC_3a430/fast"
make[3]: Entering directory '/home/joncrall/code/VIAME/build-py2/build/src/burnout-build/CMakeFiles/CMakeTmp'
/usr/bin/make -f CMakeFiles/cmTC_3a430.dir/build.make CMakeFiles/cmTC_3a430.dir/build
make[4]: Entering directory '/home/joncrall/code/VIAME/build-py2/build/src/burnout-build/CMakeFiles/CMakeTmp'
Building CXX object CMakeFiles/cmTC_3a430.dir/test_gdal_version.cxx.o
/usr/bin/c++    -std=c++0x  -O3 -DNDEBUG -fPIE   -I/usr/include/gdal -o CMakeFiles/cmTC_3a430.dir/test_gdal_version.cxx.o -c /home/joncrall/code/VIAME/build-py2/build/src/burnout-build/test_gdal_version.cxx
/home/joncrall/code/VIAME/build-py2/build/src/burnout-build/test_gdal_version.cxx:3:2: error: #error "GDAL Not required version: $GDAL_VERSION_NUM"
 #error "GDAL Not required version: $GDAL_VERSION_NUM"
  ^
CMakeFiles/cmTC_3a430.dir/build.make:65: recipe for target 'CMakeFiles/cmTC_3a430.dir/test_gdal_version.cxx.o' failed
make[4]: *** [CMakeFiles/cmTC_3a430.dir/test_gdal_version.cxx.o] Error 1
make[4]: Leaving directory '/home/joncrall/code/VIAME/build-py2/build/src/burnout-build/CMakeFiles/CMakeTmp'
Makefile:126: recipe for target 'cmTC_3a430/fast' failed
make[3]: *** [cmTC_3a430/fast] Error 2
make[3]: Leaving directory '/home/joncrall/code/VIAME/build-py2/build/src/burnout-build/CMakeFiles/CMakeTmp'

-- Boost version: 1.55.0
-- Found the following Boost libraries:
--   thread
--   filesystem
--   system
--   date_time
--   regex
--   chrono
--   atomic
-- Could NOT find LTIDSDK: Found unsuitable version "0.0.0", but required is at least "8.5" (found LTIDSDK_INCLUDE_DIR-NOTFOUND)
-- Performing Test have_warning_flag-format=2
-- Performing Test have_warning_flag-format=2 - Success
-- Making library "vidtk_logger_mini_logger"
-- BRL not built with VXL, skipping gmm
-- Making library "vidtk_track_io_plugin"
-- Making library "vidtk_image_object_io_plugin"
-- Making library "vidtk_raw_descriptor_io_plugin"
-- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE) (Required is at least version "1.8.1")
-- Configuring done
-- Generating done
-- Build files have been written to: /home/joncrall/code/VIAME/build-py2/build/src/burnout-build
[ 17%] Removing burnout build stamp file for build update (forcebuild).
[ 18%] Performing build step for 'burnout'
[  2%] Built target vidtksys
[  2%] Built target vidtk_geographic
[  3%] Building CXX object wrappers/vil_plugins/CMakeFiles/vidtk_vil_plugins.dir/file_formats/vil_nitf_engrda.cxx.o
/home/joncrall/code/VIAME/packages/burn-out/wrappers/vil_plugins/file_formats/vil_nitf_engrda.cxx:11:33: fatal error: vbl/vbl_smart_ptr.txx: No such file or directory
compilation terminated.
wrappers/vil_plugins/CMakeFiles/vidtk_vil_plugins.dir/build.make:86: recipe for target 'wrappers/vil_plugins/CMakeFiles/vidtk_vil_plugins.dir/file_formats/vil_nitf_engrda.cxx.o' failed
make[5]: *** [wrappers/vil_plugins/CMakeFiles/vidtk_vil_plugins.dir/file_formats/vil_nitf_engrda.cxx.o] Error 1
CMakeFiles/Makefile2:236: recipe for target 'wrappers/vil_plugins/CMakeFiles/vidtk_vil_plugins.dir/all' failed
make[4]: *** [wrappers/vil_plugins/CMakeFiles/vidtk_vil_plugins.dir/all] Error 2
Makefile:151: recipe for target 'all' failed
make[3]: *** [all] Error 2
CMakeFiles/burnout.dir/build.make:113: recipe for target 'build/src/burnout-stamp/burnout-build' failed
make[2]: *** [build/src/burnout-stamp/burnout-build] Error 2
CMakeFiles/Makefile2:183: recipe for target 'CMakeFiles/burnout.dir/all' failed
make[1]: *** [CMakeFiles/burnout.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2
```

Previously there was no way to tell burnout not to use GDAL if it found it. Now there is and it seems to build fine. 