### PR TITLE
Remove geo_coords::inverse_flattening

### DIFF
--- a/wrappers/geographic/geo_coords.cxx
+++ b/wrappers/geographic/geo_coords.cxx
@@ -354,14 +354,6 @@ geo_coords
 }
 
 
-double
-geo_coords
-::inverse_flattening() const
-{
-  return this->impl_->c.InverseFlattening();
-}
-
-
 bool
 geo_coords
 ::is_valid(void) const

--- a/wrappers/geographic/geo_coords.h
+++ b/wrappers/geographic/geo_coords.h
@@ -323,13 +323,6 @@ public:
   double major_radius() const;
 
   /**
-   * The inverse flattening of the ellipsoid.  This is the value for the
-   * WGS84 ellipsoid because the UTM and UPS projections are based on this
-   * ellipsoid.
-   **********************************************************************/
-  double inverse_flattening() const;
-
-  /**
    *Check whether or not the object has valid coordinates
    **********************************************************************/
   bool is_valid(void) const;


### PR DESCRIPTION
Remove aforementioned method, as the upstream method it wrapped has been
removed as of GoegraphicLib 1.46. (Fortunately, it does not seem to be
used by anyone.)